### PR TITLE
fix(apy): price exchange rate on effective stake

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -188,6 +188,36 @@ jobs:
             docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml stop indexer 2>/dev/null || true
             docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml rm -f indexer 2>/dev/null || true
 
+            # Apply pending migrations while the indexer is stopped but postgres is
+            # still up. Must happen here: migrations rewrite historical rows, so the
+            # old indexer must not be running, and the new one must not start first.
+            # Mirrors scripts/deploy-schema.sh, which is the manual equivalent.
+            echo "🗄️ Applying database migrations"
+            PG=\$(docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml ps -q postgres)
+            pg_sql() { docker exec -i \$PG psql -U indexer -d ls_indexer "\$@"; }
+
+            pg_sql -q -c "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW());"
+
+            # 001 predates this tracking table on existing databases - adopt it rather
+            # than replaying it, since it drops and recreates the transactions table
+            if [ "\$(pg_sql -tAc "SELECT count(*) FROM schema_migrations;")" = "0" ]; then
+              if [ "\$(pg_sql -tAc "SELECT to_regclass('public.transaction_content') IS NOT NULL;")" = "t" ]; then
+                echo "  ℹ️ existing schema detected - baselining 001 as applied"
+                pg_sql -q -c "INSERT INTO schema_migrations (filename) VALUES ('001_transaction_content_separation.sql') ON CONFLICT DO NOTHING;"
+              fi
+            fi
+
+            for f in src/db/migrations/*.sql; do
+              name=\$(basename "\$f")
+              if [ "\$(pg_sql -tAc "SELECT 1 FROM schema_migrations WHERE filename = '\$name';")" = "1" ]; then
+                echo "  ⏭️ \$name already applied"
+                continue
+              fi
+              echo "  applying \$name"
+              docker exec -i \$PG psql -v ON_ERROR_STOP=1 -U indexer -d ls_indexer < "\$f"
+              pg_sql -q -c "INSERT INTO schema_migrations (filename) VALUES ('\$name');"
+            done
+
             # Rebuild and start indexer
             docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml build --no-cache indexer
             docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml up -d

--- a/example-graph/src/APYDisplay.tsx
+++ b/example-graph/src/APYDisplay.tsx
@@ -1,11 +1,14 @@
 import React, { FC, useState, useEffect } from 'react'
 
 interface APYData {
-  apy24h: string
-  apy7d: string
-  apy30d: string
+  apy24h: string | null
+  apy7d: string | null
+  apy30d: string | null
   syncComplete: boolean
 }
+
+// null means the window could not be measured, not zero yield
+const formatAPY = (value: string | null) => (value != null ? `${value}%` : '—')
 
 const APYDisplay: FC = () => {
   const [data, setData] = useState<APYData | null>(null)
@@ -72,7 +75,7 @@ const APYDisplay: FC = () => {
         <div className="bg-gradient-to-br from-blue-50 to-blue-100 rounded-lg p-4">
           <div className="text-sm text-blue-600 font-medium mb-1">24 Hour</div>
           <div className="text-3xl font-bold text-blue-900">
-            {data.apy24h}%
+            {formatAPY(data.apy24h)}
           </div>
           <div className="text-xs text-blue-600 mt-1">Last day</div>
         </div>
@@ -81,7 +84,7 @@ const APYDisplay: FC = () => {
         <div className="bg-gradient-to-br from-purple-50 to-purple-100 rounded-lg p-4">
           <div className="text-sm text-purple-600 font-medium mb-1">7 Day</div>
           <div className="text-3xl font-bold text-purple-900">
-            {data.apy7d}%
+            {formatAPY(data.apy7d)}
           </div>
           <div className="text-xs text-purple-600 mt-1">Last week</div>
         </div>
@@ -90,7 +93,7 @@ const APYDisplay: FC = () => {
         <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-lg p-4">
           <div className="text-sm text-green-600 font-medium mb-1">30 Day</div>
           <div className="text-3xl font-bold text-green-900">
-            {data.apy30d}%
+            {formatAPY(data.apy30d)}
           </div>
           <div className="text-xs text-green-600 mt-1">Last month</div>
         </div>

--- a/scripts/check-effective-stake-drift.sql
+++ b/scripts/check-effective-stake-drift.sql
@@ -1,0 +1,105 @@
+-- Sizes the impact of migration 002 before running it. Read-only.
+--
+-- If buy-in was never active, every number below is 0 and the migration is a
+-- no-op - the stored rates were already correct.
+
+\echo '== how much of history had buy-in tokens locked =='
+WITH locked AS (
+  SELECT cs.block_number,
+         cs.timestamp,
+         cs.total_pool_stake_token,
+         cs.total_pool_liquid,
+         cs.exchange_rate AS stored_rate,
+         COALESCE((
+           SELECT pp.amount_of_buy_in_locked_stake_tokens
+           FROM protocol_parameters pp
+           WHERE pp.block_number <= cs.block_number
+             AND pp.amount_of_buy_in_locked_stake_tokens IS NOT NULL
+           ORDER BY pp.block_number DESC
+           LIMIT 1
+         ), 0) AS buy_in_locked
+  FROM contract_states cs
+)
+SELECT COUNT(*) FILTER (WHERE buy_in_locked > 0) AS blocks_with_locked_tokens,
+       COUNT(*)                                  AS blocks_total,
+       ROUND(100.0 * COUNT(*) FILTER (WHERE buy_in_locked > 0) / NULLIF(COUNT(*), 0), 2) AS pct_affected,
+       MIN(timestamp) FILTER (WHERE buy_in_locked > 0) AS first_affected,
+       MAX(timestamp) FILTER (WHERE buy_in_locked > 0) AS last_affected
+FROM locked;
+
+\echo ''
+\echo '== worst-case overstatement of the exchange rate =='
+WITH locked AS (
+  SELECT cs.block_number,
+         cs.timestamp,
+         cs.total_pool_stake_token,
+         cs.total_pool_liquid,
+         cs.exchange_rate AS stored_rate,
+         COALESCE((
+           SELECT pp.amount_of_buy_in_locked_stake_tokens
+           FROM protocol_parameters pp
+           WHERE pp.block_number <= cs.block_number
+             AND pp.amount_of_buy_in_locked_stake_tokens IS NOT NULL
+           ORDER BY pp.block_number DESC
+           LIMIT 1
+         ), 0) AS buy_in_locked
+  FROM contract_states cs
+),
+corrected AS (
+  SELECT *,
+         CASE
+           WHEN total_pool_liquid = 0 OR total_pool_stake_token <= buy_in_locked THEN 1.0
+           ELSE TRUNC((total_pool_stake_token - buy_in_locked)::numeric / total_pool_liquid, 10)
+         END AS correct_rate
+  FROM locked
+)
+SELECT block_number,
+       timestamp,
+       stored_rate,
+       correct_rate,
+       ROUND(100.0 * (stored_rate - correct_rate) / NULLIF(correct_rate, 0), 4) AS overstated_pct
+FROM corrected
+WHERE stored_rate IS DISTINCT FROM correct_rate
+ORDER BY (stored_rate - correct_rate) DESC
+LIMIT 10;
+
+\echo ''
+\echo '== effect on the published 30d APY =='
+-- compares APY computed from stored vs corrected rates over the same window
+WITH locked AS (
+  SELECT cs.block_number, cs.timestamp, cs.total_pool_stake_token,
+         cs.total_pool_liquid, cs.exchange_rate AS stored_rate,
+         COALESCE((
+           SELECT pp.amount_of_buy_in_locked_stake_tokens
+           FROM protocol_parameters pp
+           WHERE pp.block_number <= cs.block_number
+             AND pp.amount_of_buy_in_locked_stake_tokens IS NOT NULL
+           ORDER BY pp.block_number DESC LIMIT 1
+         ), 0) AS buy_in_locked
+  FROM contract_states cs
+  WHERE cs.total_pool_liquid > 0
+),
+corrected AS (
+  SELECT *,
+         CASE WHEN total_pool_stake_token <= buy_in_locked THEN 1.0
+              ELSE TRUNC((total_pool_stake_token - buy_in_locked)::numeric / total_pool_liquid, 10)
+         END AS correct_rate
+  FROM locked
+),
+bounds AS (
+  SELECT (SELECT MAX(timestamp) FROM corrected) AS t2,
+         (SELECT MAX(timestamp) FROM corrected
+          WHERE timestamp <= (SELECT MAX(timestamp) FROM corrected) - INTERVAL '30 days') AS t1
+),
+endpoints AS (
+  SELECT
+    (SELECT stored_rate  FROM corrected WHERE timestamp = (SELECT t1 FROM bounds) ORDER BY block_number DESC LIMIT 1) AS stored_r1,
+    (SELECT stored_rate  FROM corrected WHERE timestamp = (SELECT t2 FROM bounds) ORDER BY block_number DESC LIMIT 1) AS stored_r2,
+    (SELECT correct_rate FROM corrected WHERE timestamp = (SELECT t1 FROM bounds) ORDER BY block_number DESC LIMIT 1) AS correct_r1,
+    (SELECT correct_rate FROM corrected WHERE timestamp = (SELECT t2 FROM bounds) ORDER BY block_number DESC LIMIT 1) AS correct_r2,
+    EXTRACT(EPOCH FROM ((SELECT t2 FROM bounds) - (SELECT t1 FROM bounds))) / 86400.0 AS actual_days
+)
+SELECT ROUND(actual_days::numeric, 4) AS actual_days,
+       ROUND((100 * (POWER(stored_r2  / NULLIF(stored_r1, 0),  365 / actual_days) - 1))::numeric, 2) AS apy30d_stored,
+       ROUND((100 * (POWER(correct_r2 / NULLIF(correct_r1, 0), 365 / actual_days) - 1))::numeric, 2) AS apy30d_corrected
+FROM endpoints;

--- a/scripts/deploy-schema.sh
+++ b/scripts/deploy-schema.sh
@@ -14,7 +14,7 @@ DB_PASSWORD="${PGPASSWORD}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
-MIGRATIONS_DIR="$PROJECT_ROOT/migrations"
+MIGRATIONS_DIR="$PROJECT_ROOT/src/db/migrations"
 
 echo "🗄️  Partisia Indexer Database Schema Deployment"
 echo "================================================"
@@ -42,14 +42,49 @@ echo "✅ Database connection successful"
 echo ""
 echo "🔄 Applying database migrations..."
 
+if ! compgen -G "$MIGRATIONS_DIR/*.sql" >/dev/null; then
+    echo "❌ No migrations found in $MIGRATIONS_DIR"
+    exit 1
+fi
+
+psql_do() {
+    PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" "$@"
+}
+
+# Migrations are applied exactly once and recorded here. Without this, re-running
+# the script replays every file - and 001 drops and recreates the transactions
+# table, so a replay silently destroys indexed history.
+psql_do -q -c "CREATE TABLE IF NOT EXISTS schema_migrations (
+    filename TEXT PRIMARY KEY,
+    applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);"
+
+# Baseline: this tracking table was introduced after 001 had already been applied
+# to existing databases. If its objects are present but nothing is recorded, adopt
+# the current state rather than replaying it.
+if [ "$(psql_do -tAc "SELECT count(*) FROM schema_migrations;")" = "0" ]; then
+    if [ "$(psql_do -tAc "SELECT to_regclass('public.transaction_content') IS NOT NULL;")" = "t" ]; then
+        echo "  ℹ️  Existing schema detected - baselining 001 as already applied"
+        psql_do -q -c "INSERT INTO schema_migrations (filename) VALUES ('001_transaction_content_separation.sql') ON CONFLICT DO NOTHING;"
+    fi
+fi
+
 for migration_file in "$MIGRATIONS_DIR"/*.sql; do
     if [ -f "$migration_file" ]; then
         migration_name=$(basename "$migration_file")
+
+        already="$(psql_do -tAc "SELECT 1 FROM schema_migrations WHERE filename = '$migration_name';")"
+        if [ "$already" = "1" ]; then
+            echo "  ⏭️  $migration_name already applied - skipping"
+            continue
+        fi
+
         echo "  Applying $migration_name..."
 
-        PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" -f "$migration_file"
-
-        if [ $? -eq 0 ]; then
+        # ON_ERROR_STOP so a failing statement aborts instead of continuing and
+        # then being recorded as applied
+        if psql_do -v ON_ERROR_STOP=1 -f "$migration_file"; then
+            psql_do -q -c "INSERT INTO schema_migrations (filename) VALUES ('$migration_name');"
             echo "  ✅ $migration_name applied successfully"
         else
             echo "  ❌ Failed to apply $migration_name"

--- a/src/api/README.md
+++ b/src/api/README.md
@@ -188,14 +188,38 @@ All API responses follow a consistent format:
 ### Analytics
 - **GET /api/v1/analytics/apy**
   - Returns APY calculations for 24h, 7d, and 30d periods
+  - Each figure is `null` when the window cannot be measured (sync incomplete,
+    or history does not reach back that far). `null` means unknown — it is never
+    reported as `"0.00"`, so callers can distinguish it from genuine zero yield.
+  - `windows` reports the span actually measured. `r1` is the newest snapshot at
+    or before the boundary, so `actualDays >= requestedDays`.
+  - `datapoints` is `[r1, r2]` — the two rates the figure is derived from, in
+    unix seconds — so clients can show the working. Recomputing
+    `(r2/r1) ^ (365 / actualDays) - 1` from them reproduces the published value.
   ```json
   {
     "apy24h": "5.23",
     "apy7d": "5.18",
     "apy30d": "5.15",
+    "windows": {
+      "apy30d": {
+        "requestedDays": 30,
+        "actualDays": 30.114,
+        "fromBlock": 4210567,
+        "toBlock": 5555001,
+        "datapoints": [
+          { "timestamp": 1751932800, "rate": "1.0512340000" },
+          { "timestamp": 1754535262, "rate": "1.0556120000" }
+        ]
+      }
+    },
+    "latestTimestamp": "2026-07-28T09:14:22.000Z",
     "syncComplete": true
   }
   ```
+  - Formula: `APY = (r2 / r1) ^ (365 / actualDays) - 1`, where the exchange rate
+    is `(total_pool_stake_token - amount_of_buy_in_locked_stake_tokens) / total_pool_liquid`
+    — the same effective stake the contract uses to price redemptions.
 
 - **GET /api/v1/analytics/daily**
   - Query params: `days` (default: 30, min: 1, max: 365)

--- a/src/api/v1/analytics.ts
+++ b/src/api/v1/analytics.ts
@@ -23,74 +23,112 @@ export function createAnalyticsRouter(): Router {
       const stats = await indexer.getStats();
 
       if (!stats.syncComplete || !stats.canCalculateAPY) {
+        // null, not "0.00" - callers must be able to tell "unknown" from "no yield"
         return res.apiSuccess({
-          apy24h: "0.00",
-          apy7d: "0.00",
-          apy30d: "0.00",
+          apy24h: null,
+          apy7d: null,
+          apy30d: null,
+          windows: null,
           syncComplete: false,
           progressPercent: stats.progressPercent.toFixed(1),
           note: `Sync incomplete: ${stats.progressPercent.toFixed(1)}% - APY calculation disabled`
         });
       }
 
-      const allData = await db.query(`
-        SELECT exchange_rate, timestamp
-        FROM contract_states
-        ORDER BY timestamp ASC
-      `);
+      // an empty liquid pool or a fully buy-in-locked stake pool yields a
+      // synthesized rate of 1.0 (see indexer buildContractState) - that is a
+      // placeholder, not a measured rate, and must not anchor a window
+      const MEASURABLE = `
+        total_pool_liquid > 0
+        AND total_pool_stake_token > COALESCE(amount_of_buy_in_locked_stake_tokens, 0)
+      `;
 
-      if (allData.rows.length < 2) {
+      const latestResult = await db.query(`
+        SELECT exchange_rate, timestamp, block_number
+        FROM contract_states
+        WHERE ${MEASURABLE}
+        ORDER BY timestamp DESC, block_number DESC
+        LIMIT 1
+      `);
+      const latest = latestResult.rows[0];
+
+      if (!latest) {
         return res.apiSuccess({
           apy24h: null,
           apy7d: null,
           apy30d: null,
+          windows: null,
+          syncComplete: true,
           note: "Insufficient data for APY calculation"
         });
       }
 
-      const now = new Date();
-      const points = allData.rows;
-      const latest = points[points.length - 1];
+      // windows anchor to the newest indexed state rather than wall clock, so a
+      // lagging indexer shortens the window instead of collapsing it to null
+      const latestTime = new Date(latest.timestamp);
 
-      // Find closest historical points for precise APY calc
-      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-      const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      const calculateAPY = async (targetDays: number) => {
+        const target = new Date(latestTime.getTime() - targetDays * 24 * 60 * 60 * 1000);
 
-      const findAtOrBefore = (targetTime: Date) => {
-        let candidate = points[0];
-        for (const p of points) {
-          const t = new Date(p.timestamp);
-          if (t <= targetTime) {
-            candidate = p;
-          } else {
-            break;
-          }
-        }
-        return candidate;
+        // newest snapshot at or before the boundary, index-served rather than
+        // scanned in JS - so actualDays >= targetDays by construction
+        const prior = await db.query(`
+          SELECT exchange_rate, timestamp, block_number
+          FROM contract_states
+          WHERE ${MEASURABLE} AND timestamp <= $1
+          ORDER BY timestamp DESC, block_number DESC
+          LIMIT 1
+        `, [target]);
+
+        const oldPoint = prior.rows[0];
+
+        // history does not reach back this far - the window is unavailable, and
+        // must not silently degrade into a since-inception figure
+        if (!oldPoint || oldPoint.block_number === latest.block_number) return null;
+
+        const actualDays = (latestTime.getTime() - new Date(oldPoint.timestamp).getTime()) / (1000 * 60 * 60 * 24);
+        if (actualDays <= 0) return null;
+
+        const oldRate = parseFloat(oldPoint.exchange_rate);
+        const newRate = parseFloat(latest.exchange_rate);
+        if (!(oldRate > 0) || !(newRate > 0)) return null;
+
+        const annualized = Math.pow(newRate / oldRate, 365 / actualDays);
+        if (!Number.isFinite(annualized)) return null;
+
+        return {
+          apy: (annualized - 1) * 100,
+          actualDays,
+          fromBlock: Number(oldPoint.block_number),
+          toBlock: Number(latest.block_number),
+          // [r1, r2] - the two rates the figure is derived from, so clients can
+          // show the working. Unix seconds, matching the rest of the v1 API.
+          datapoints: [
+            { timestamp: Math.floor(new Date(oldPoint.timestamp).getTime() / 1000), rate: String(oldPoint.exchange_rate) },
+            { timestamp: Math.floor(latestTime.getTime() / 1000), rate: String(latest.exchange_rate) }
+          ]
+        };
       };
 
-      const dayPoint = findAtOrBefore(oneDayAgo);
-      const weekPoint = findAtOrBefore(sevenDaysAgo);
-      const monthPoint = findAtOrBefore(thirtyDaysAgo);
-
-      const calculateAPY = (oldPoint: any, newPoint: any) => {
-        const timeDiff = (new Date(newPoint.timestamp).getTime() - new Date(oldPoint.timestamp).getTime()) / (1000 * 60 * 60 * 24);
-        if (timeDiff <= 0) return null;
-
-        const rateChange = parseFloat(newPoint.exchange_rate) / parseFloat(oldPoint.exchange_rate);
-        const annualizedMultiplier = Math.pow(rateChange, 365 / timeDiff);
-        return (annualizedMultiplier - 1) * 100;
-      };
-
-      const apy24h = dayPoint !== latest ? calculateAPY(dayPoint, latest) : null;
-      const apy7d = weekPoint !== latest ? calculateAPY(weekPoint, latest) : null;
-      const apy30d = monthPoint !== latest ? calculateAPY(monthPoint, latest) : null;
+      const [w24h, w7d, w30d] = await Promise.all([
+        calculateAPY(1),
+        calculateAPY(7),
+        calculateAPY(30)
+      ]);
 
       res.apiSuccess({
-        apy24h: apy24h !== null ? apy24h.toFixed(2) : "0.00",
-        apy7d: apy7d !== null ? apy7d.toFixed(2) : "0.00",
-        apy30d: apy30d !== null ? apy30d.toFixed(2) : "0.00",
+        apy24h: w24h ? w24h.apy.toFixed(2) : null,
+        apy7d: w7d ? w7d.apy.toFixed(2) : null,
+        apy30d: w30d ? w30d.apy.toFixed(2) : null,
+        // measured span backing each figure. r1 is the newest snapshot at or
+        // before the boundary, so actualDays >= requestedDays - it overshoots
+        // when snapshots are sparse around the boundary, never undershoots
+        windows: {
+          apy24h: w24h && { requestedDays: 1, actualDays: Number(w24h.actualDays.toFixed(4)), fromBlock: w24h.fromBlock, toBlock: w24h.toBlock, datapoints: w24h.datapoints },
+          apy7d: w7d && { requestedDays: 7, actualDays: Number(w7d.actualDays.toFixed(4)), fromBlock: w7d.fromBlock, toBlock: w7d.toBlock, datapoints: w7d.datapoints },
+          apy30d: w30d && { requestedDays: 30, actualDays: Number(w30d.actualDays.toFixed(4)), fromBlock: w30d.fromBlock, toBlock: w30d.toBlock, datapoints: w30d.datapoints }
+        },
+        latestTimestamp: latestTime.toISOString(),
         syncComplete: true
       });
     } catch (error) {

--- a/src/db/migrations/002_effective_stake_exchange_rate.sql
+++ b/src/db/migrations/002_effective_stake_exchange_rate.sql
@@ -1,0 +1,56 @@
+-- 002: exchange_rate must be priced on effective stake
+--
+-- exchange_rate was stored as total_pool_stake_token / total_pool_liquid, but the
+-- contract prices every redemption on effective_stake():
+--   total_pool_stake_token - amount_of_buy_in_locked_stake_tokens
+-- (see liquid-staking/src/lib.rs effective_stake / exchange_rate_*). Stored rates
+-- therefore overstate redeemable value for any block where buy-in tokens were
+-- locked, and every APY derived from those rates inherits the error.
+--
+-- contract_states never persisted the locked amount (the INSERT wrote 8 columns
+-- and skipped it), so it is reconstructed from protocol_parameters, which records
+-- the value as a step function - one row per change, FK'd to contract_states.
+--
+-- Run scripts/check-effective-stake-drift.sql first to size the impact.
+
+BEGIN;
+
+-- 1. carry the locked amount onto every contract_states row. Blocks before the
+-- first protocol_parameters row predate any buy-in and settle to 0.
+UPDATE contract_states cs
+SET amount_of_buy_in_locked_stake_tokens = COALESCE((
+  SELECT pp.amount_of_buy_in_locked_stake_tokens
+  FROM protocol_parameters pp
+  WHERE pp.block_number <= cs.block_number
+    AND pp.amount_of_buy_in_locked_stake_tokens IS NOT NULL
+  ORDER BY pp.block_number DESC
+  LIMIT 1
+), 0);
+
+-- 2. recompute the rate to match indexer buildContractState exactly: 1.0 when
+-- there is no liquid supply or no effective stake, otherwise effective stake over
+-- liquid supply. TRUNC (not ROUND) to 10dp mirrors the integer division the
+-- indexer does at 1e10 scale.
+UPDATE contract_states
+SET exchange_rate = CASE
+  WHEN total_pool_liquid = 0
+    OR total_pool_stake_token <= amount_of_buy_in_locked_stake_tokens
+  THEN 1.0
+  ELSE TRUNC(
+    (total_pool_stake_token - amount_of_buy_in_locked_stake_tokens)::numeric
+      / total_pool_liquid, 10)
+END;
+
+-- 3. current_state is a denormalized mirror of the newest contract_states row
+UPDATE current_state csr
+SET exchange_rate = cs.exchange_rate,
+    amount_of_buy_in_locked_stake_tokens = cs.amount_of_buy_in_locked_stake_tokens
+FROM (
+  SELECT exchange_rate, amount_of_buy_in_locked_stake_tokens
+  FROM contract_states
+  ORDER BY block_number DESC
+  LIMIT 1
+) cs
+WHERE csr.id = 1;
+
+COMMIT;

--- a/src/indexer.ts
+++ b/src/indexer.ts
@@ -303,21 +303,23 @@ class PartisiaIndexer {
       console.log(`🔹 Inserting ${context.contractStates.length} contract_states: blocks ${blocks}`);
 
       const values = context.contractStates.map((s: any, i: number) => {
-        const offset = i * 8;
-        return `($${offset+1}, $${offset+2}, $${offset+3}, $${offset+4}, $${offset+5}, $${offset+6}, $${offset+7}, $${offset+8})`;
+        const offset = i * 9;
+        return `($${offset+1}, $${offset+2}, $${offset+3}, $${offset+4}, $${offset+5}, $${offset+6}, $${offset+7}, $${offset+8}, $${offset+9})`;
       }).join(',');
 
       const params = context.contractStates.flatMap((s: any) => [
         s.blockNumber, s.timestamp, s.exchangeRate,
         s.stakeAmount, s.liquidAmount, s.stakeTokenBalance,
-        s.buyInPercentage, s.buyInEnabled
+        s.buyInPercentage, s.buyInEnabled, s.buyInLockedTokens
       ]);
 
+      // amount_of_buy_in_locked_stake_tokens is persisted here so exchange_rate
+      // stays reproducible from the row itself - it is a term in the rate
       await db.query(`
         INSERT INTO contract_states (
           block_number, timestamp, exchange_rate,
           total_pool_stake_token, total_pool_liquid, stake_token_balance,
-          buy_in_percentage, buy_in_enabled
+          buy_in_percentage, buy_in_enabled, amount_of_buy_in_locked_stake_tokens
         ) VALUES ${values}
         ON CONFLICT (block_number) DO UPDATE SET
           timestamp = EXCLUDED.timestamp,
@@ -326,7 +328,8 @@ class PartisiaIndexer {
           total_pool_liquid = EXCLUDED.total_pool_liquid,
           stake_token_balance = EXCLUDED.stake_token_balance,
           buy_in_percentage = EXCLUDED.buy_in_percentage,
-          buy_in_enabled = EXCLUDED.buy_in_enabled
+          buy_in_enabled = EXCLUDED.buy_in_enabled,
+          amount_of_buy_in_locked_stake_tokens = EXCLUDED.amount_of_buy_in_locked_stake_tokens
       `, params);
 
       console.log(`✅ contract_states inserted successfully`);
@@ -509,13 +512,18 @@ class PartisiaIndexer {
     const stakeAmount = BigInt(state.totalPoolStakeToken?.toString() || '0');
     const liquidAmount = BigInt(state.totalPoolLiquid?.toString() || '0');
     const stakeTokenBalance = BigInt(state.stakeTokenBalance?.toString() || '0');
+    const buyInLocked = BigInt(state.amountOfBuyInLockedStakeTokens?.toString() || '0');
 
-    // Exchange rate = stakeAmount / liquidAmount (how many MPC you get per 1 sMPC)
+    // Exchange rate = effectiveStake / liquidAmount (how many MPC you get per 1 sMPC).
+    // Must mirror the contract's effective_stake(): buy-in locked tokens sit in
+    // total_pool_stake_token but are excluded from every redemption calculation,
+    // so including them here overstates what a holder can actually redeem.
     // As rewards accrue, each sMPC represents more MPC, so rate should be >= 1.0
     // Use high precision: multiply by 1e10, divide, then scale back to float
-    const exchangeRate = liquidAmount === 0n
+    const effectiveStake = stakeAmount > buyInLocked ? stakeAmount - buyInLocked : 0n;
+    const exchangeRate = liquidAmount === 0n || effectiveStake === 0n
       ? 1.0
-      : Number((stakeAmount * 10_000_000_000n) / liquidAmount) / 10_000_000_000;
+      : Number((effectiveStake * 10_000_000_000n) / liquidAmount) / 10_000_000_000;
 
     const hasActivity = (
       stakeAmount !== 0n ||
@@ -616,6 +624,7 @@ class PartisiaIndexer {
         stakeTokenBalance: state.stakeTokenBalance?.toString() || '0',
         buyInPercentage: state.buyInPercentage?.toString() || '0',
         buyInEnabled: state.buyInEnabled || false,
+        buyInLockedTokens: buyInLocked.toString(),
         exchange_rate: currentState.exchangeRate,
         total_pool_stake_token: currentState.totalPoolStakeToken,
         total_pool_liquid: currentState.totalPoolLiquid,

--- a/test-apy.ts
+++ b/test-apy.ts
@@ -1,0 +1,126 @@
+import { mock } from 'bun:test'
+
+const ROOT = import.meta.dir
+
+// ---- fixture ------------------------------------------------------------
+// rows are newest-last; exchange_rate grows at a steady daily factor
+const DAY_MS = 24 * 60 * 60 * 1000
+const T0 = new Date('2026-06-01T00:00:00Z').getTime()
+const DAILY_GROWTH = 1.0002 // ~7.57% APY
+
+function makeRows(days: number) {
+  const rows: any[] = []
+  for (let d = 0; d <= days; d++) {
+    rows.push({
+      block_number: String(1000 + d),
+      timestamp: new Date(T0 + d * DAY_MS),
+      exchange_rate: (1.05 * Math.pow(DAILY_GROWTH, d)).toFixed(10),
+      total_pool_liquid: '1000',
+      total_pool_stake_token: '1100',
+    })
+  }
+  return rows
+}
+
+let ROWS: any[] = []
+
+// ---- stubs --------------------------------------------------------------
+const fakeDb = {
+  query: async (sql: string, params?: any[]) => {
+    const usable = ROWS // MEASURABLE filter is a no-op for this fixture
+    if (/timestamp <= \$1/.test(sql)) {
+      const target = new Date(params![0]).getTime()
+      const hits = usable
+        .filter(r => new Date(r.timestamp).getTime() <= target)
+        .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
+      return { rows: hits.slice(0, 1) }
+    }
+    const desc = [...usable].sort(
+      (a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime(),
+    )
+    return { rows: desc.slice(0, 1) }
+  },
+}
+
+let STATS = { syncComplete: true, canCalculateAPY: true, progressPercent: 100 }
+
+mock.module(`${ROOT}/src/db/client.ts`, () => ({ default: fakeDb }))
+mock.module(`${ROOT}/src/config/index.ts`, () => ({ default: {} }))
+mock.module(`${ROOT}/src/utils/denomination.ts`, () => ({ fromRawAmount: (x: any) => x }))
+mock.module(`${ROOT}/src/indexer.ts`, () => ({ default: { getStats: async () => STATS } }))
+
+const { createAnalyticsRouter } = await import(`${ROOT}/src/api/v1/analytics.ts`)
+
+// ---- harness ------------------------------------------------------------
+const router: any = createAnalyticsRouter()
+const layer = router.stack.find(
+  (l: any) => l.route?.path === '/apy' && l.route.methods.get,
+)
+const handler = layer.route.stack[0].handle
+
+async function callApy() {
+  let payload: any
+  const res: any = { apiSuccess: (d: any) => { payload = d } }
+  await handler({ query: {} } as any, res, (e: any) => { throw e })
+  return payload
+}
+
+// ---- assertions ---------------------------------------------------------
+let failures = 0
+function check(name: string, cond: boolean, detail = '') {
+  if (cond) console.log(`  ok   ${name}`)
+  else { console.log(`  FAIL ${name} ${detail}`); failures++ }
+}
+
+// A: 40 days of history -> all windows measurable
+ROWS = makeRows(40)
+let out = await callApy()
+console.log('A: 40 days of history')
+const expected30 = (Math.pow(Math.pow(DAILY_GROWTH, 30), 365 / 30) - 1) * 100
+check('apy30d present', out.apy30d !== null, JSON.stringify(out.apy30d))
+check(
+  `apy30d ~= ${expected30.toFixed(2)}`,
+  Math.abs(parseFloat(out.apy30d) - expected30) < 0.05,
+  `got ${out.apy30d}`,
+)
+check('actualDays >= 30', out.windows.apy30d.actualDays >= 30, String(out.windows.apy30d.actualDays))
+check('apy24h and apy7d present', out.apy24h !== null && out.apy7d !== null)
+check('all windows agree (constant growth)',
+  Math.abs(parseFloat(out.apy24h) - parseFloat(out.apy30d)) < 0.05,
+  `24h=${out.apy24h} 30d=${out.apy30d}`)
+
+// the datapoints must reproduce the published figure - the tooltip shows this
+// working, so if they disagree the UI is displaying arithmetic that is not the
+// arithmetic that produced the number
+const dp = out.windows.apy30d.datapoints
+check('datapoints are [r1, r2]', dp.length === 2)
+check('datapoints are unix seconds',
+  dp[0].timestamp > 1e9 && dp[0].timestamp < 1e11, String(dp[0].timestamp))
+check('datapoints ordered oldest first', dp[0].timestamp < dp[1].timestamp)
+const reproduced =
+  (Math.pow(Number(dp[1].rate) / Number(dp[0].rate),
+    365 / out.windows.apy30d.actualDays) - 1) * 100
+check('datapoints reproduce the published apy30d',
+  Math.abs(reproduced - parseFloat(out.apy30d)) < 0.01,
+  `formula=${reproduced.toFixed(4)} published=${out.apy30d}`)
+check('deltaT from datapoints matches actualDays',
+  Math.abs((dp[1].timestamp - dp[0].timestamp) / 86400 - out.windows.apy30d.actualDays) < 0.01)
+
+// B: only 10 days of history -> 30d window must be null, NOT since-inception
+ROWS = makeRows(10)
+out = await callApy()
+console.log('B: 10 days of history')
+check('apy30d is null (no silent degradation)', out.apy30d === null, `got ${out.apy30d}`)
+check('apy30d window is null', out.windows.apy30d === null)
+check('apy7d still measurable', out.apy7d !== null, `got ${out.apy7d}`)
+
+// C: sync incomplete -> nulls, never "0.00"
+STATS = { syncComplete: false, canCalculateAPY: false, progressPercent: 42.5 }
+out = await callApy()
+console.log('C: sync incomplete')
+check('apy30d null not "0.00"', out.apy30d === null, `got ${JSON.stringify(out.apy30d)}`)
+check('apy24h null not "0.00"', out.apy24h === null, `got ${JSON.stringify(out.apy24h)}`)
+check('syncComplete false', out.syncComplete === false)
+
+console.log(failures === 0 ? '\nALL PASS' : `\n${failures} FAILURE(S)`)
+process.exit(failures === 0 ? 0 : 1)


### PR DESCRIPTION
## Problem

The indexer computed `exchange_rate = total_pool_stake_token / total_pool_liquid`, but the contract redeems at `effective_stake()` — which subtracts `amount_of_buy_in_locked_stake_tokens` (`liquid-staking/src/lib.rs:301-343`). Published rates, and every APY derived from them, overstated what a holder could actually redeem whenever buy-in tokens were locked.

## Changes

- **Exchange rate** now mirrors `effective_stake()`. The locked amount is also persisted into `contract_states` (the INSERT was 8 columns and skipped it), so the rate is reproducible from the row.
- **`/apy` returns `null`, never `"0.00"`** — "sync incomplete", "not enough history" and "genuinely zero yield" were previously indistinguishable.
- **Windows no longer silently degrade.** `findAtOrBefore` used to fall back to the earliest row ever, so `apy30d` could quietly become a since-inception figure. It now returns `null`.
- Window selection moved into SQL (index-served) instead of loading the whole table per request; also fixes an ordering ambiguity where `ORDER BY timestamp` could pick the wrong `latest` row.
- Response gains `windows` (measured `actualDays`, block range) and `datapoints` `[r1, r2]`, so clients can show the working.

## Deploy tooling

`deploy-schema.sh` globbed `$PROJECT_ROOT/migrations`, which does not exist — `db:migrate` has been applying **zero** migrations. Fixing the path alone would have been destructive, since `001` contains `DROP TABLE IF EXISTS transactions CASCADE` and is already applied in prod. Migrations are now tracked in `schema_migrations` and applied once, with `001` baselined rather than replayed. The deploy workflow now applies migrations in the window where the indexer is stopped but postgres is up.

## Migration

`002` repairs historical rates in place, reconstructing the locked amount from `protocol_parameters` (a step function keyed by block) — no full re-sync needed. **Run `scripts/check-effective-stake-drift.sql` first**; if buy-in was never active it reports zero drift and `002` is a no-op.

## Verification

- `test-apy.ts` (new): formula correctness, no silent degradation, null-never-zero, and that the returned datapoints reproduce the published figure
- migration + deploy script exercised against a real postgres, including a re-run: 001 baselined, 002 applied (rate 1.2 → 1.1 with 100 locked), `transaction_content` preserved, second run a clean no-op
- typecheck clean; workflow YAML parses and the expanded remote bash passes `bash -n`

Not verified against production data — the drift check needs DB access.