### PR TITLE
fix(deploy): stop docker exec -i from swallowing the deploy script

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -132,7 +132,13 @@ jobs:
           tar -czf deploy.tar.gz src scripts package.json tsconfig.json Dockerfile bun.lock docker-compose.${{ env.ENVIRONMENT }}.yaml example-graph
           scp deploy.tar.gz partisia@${{ env.SERVER_HOST }}:${{ env.DEPLOY_PATH }}/
 
-          ssh partisia@${{ env.SERVER_HOST }} << EOF
+          # Output is captured so the completion marker can be checked. A command
+          # that reads stdin inside this heredoc swallows the rest of the script,
+          # and ssh then exits 0 having silently skipped everything after it -
+          # which looks identical to success. The marker is the only proof the
+          # script ran to the end.
+          set +e
+          ssh partisia@${{ env.SERVER_HOST }} > deploy_out.log 2>&1 << EOF
             set -e
             cd ${{ env.DEPLOY_PATH }}
             tar -xzf deploy.tar.gz
@@ -199,7 +205,10 @@ jobs:
             # Mirrors scripts/deploy-schema.sh, which is the manual equivalent.
             echo "🗄️ Applying database migrations"
             PG=\$(docker compose -f docker-compose.${{ env.ENVIRONMENT }}.yaml ps -q postgres)
-            pg_sql() { docker exec -i \$PG psql -U indexer -d ls_indexer "\$@"; }
+            # NO -i here. This whole script is fed to bash over ssh via stdin, so a
+            # 'docker exec -i' without a stdin redirect consumes the rest of the
+            # script and the deploy silently stops - exiting 0, mid-way.
+            pg_sql() { docker exec \$PG psql -U indexer -d ls_indexer "\$@" < /dev/null; }
 
             pg_sql -q -c "CREATE TABLE IF NOT EXISTS schema_migrations (filename TEXT PRIMARY KEY, applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW());"
 
@@ -237,7 +246,20 @@ jobs:
             fi
 
             echo "✅ Deployment successful"
+            echo "__DEPLOY_COMPLETE__"
           EOF
+          SSH_RC=$?
+          set -e
+          cat deploy_out.log
+
+          if [ "$SSH_RC" -ne 0 ]; then
+            echo "::error::remote deploy failed (ssh exit $SSH_RC)"
+            exit 1
+          fi
+          if ! grep -q "__DEPLOY_COMPLETE__" deploy_out.log; then
+            echo "::error::deploy script ended early - output stops before the completion marker, so later steps never ran"
+            exit 1
+          fi
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
Follow-up to #5. Run 30331908344 reported **success** while taking production down.

## What happened

The remote script is piped to bash over ssh via stdin. `pg_sql()` used `docker exec -i` with no stdin redirect, so the first call consumed the remainder of the script. Migrations never ran, the indexer was never rebuilt or restarted — and `docker compose rm -f indexer` had already executed. ssh exited 0, so the job passed.

Log evidence: Deploy output stops at `🗄️ Applying database migrations` (05:32:20.6) and the next step starts at 05:32:26 — six seconds, with no build output, no `sleep 10`, no `docker compose ps`.

The pre-existing `docker exec -i` calls were safe only because they redirect stdin from a file or heredoc.

## Fix

- `pg_sql` drops `-i` and redirects from `/dev/null`
- the remote script emits `__DEPLOY_COMPLETE__`; the job fails if output stops before it

## State

Production was restored manually (`docker compose up -d`) and is serving normally on the previous image. The database was untouched: `schema_migrations` was created but is empty, so no migration applied and `exchange_rate` is unchanged.